### PR TITLE
feat: Add JPA entity classes for backend system

### DIFF
--- a/back_end/src/main/java/com/jbnu/calelog/entity/MonthlyQuota.java
+++ b/back_end/src/main/java/com/jbnu/calelog/entity/MonthlyQuota.java
@@ -1,0 +1,40 @@
+package com.jbnu.calelog.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-19
+ * @description 프로젝트별 월간 목표 시간을 관리하는 엔티티
+ *             각 프로젝트마다 월별 필수 활동 시간 설정
+ */
+@Entity
+@Table(name = "monthly_quotas", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"project_id", "year", "month"}))
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MonthlyQuota {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Column(name = "year", nullable = false)
+    private Integer year;
+
+    @Column(name = "month", nullable = false)
+    private Integer month;
+
+    @Column(name = "required_hours", nullable = false)
+    private Integer requiredHours;
+
+}

--- a/back_end/src/main/java/com/jbnu/calelog/entity/Project.java
+++ b/back_end/src/main/java/com/jbnu/calelog/entity/Project.java
@@ -1,0 +1,65 @@
+package com.jbnu.calelog.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-19
+ * @description 사용자의 활동 프로젝트 정보를 저장하는 엔티티
+ *             TA, 연구실, 동아리 등의 활동을 구분하여 관리
+ */
+@Entity
+@Table(name = "projects")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "color", nullable = false, length = 7)
+    private String color;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MonthlyQuota> monthlyQuotas = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Schedule> schedules = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ScheduleRule> scheduleRules = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+    }
+
+
+}

--- a/back_end/src/main/java/com/jbnu/calelog/entity/Schedule.java
+++ b/back_end/src/main/java/com/jbnu/calelog/entity/Schedule.java
@@ -1,0 +1,61 @@
+package com.jbnu.calelog.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-19
+ * @description 단일 일정 정보를 저장하는 엔티티
+ *             프로젝트 활동과 비활성 시간을 구분하여 관리
+ */
+@Entity
+@Table(name = "schedules")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Schedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private ScheduleType type;
+
+    @Column(name = "start_time", nullable = false)
+    private Instant startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private Instant endTime;
+
+    @Column(name = "content", length = 40)
+    private String content;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+    }
+
+    public enum ScheduleType {
+        PROJECT, INACTIVE
+    }
+
+}

--- a/back_end/src/main/java/com/jbnu/calelog/entity/ScheduleException.java
+++ b/back_end/src/main/java/com/jbnu/calelog/entity/ScheduleException.java
@@ -1,0 +1,48 @@
+package com.jbnu.calelog.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-19
+ * @description 반복 일정에 대한 예외 처리를 저장하는 엔티티
+ *             특정 날짜의 반복 일정을 수정하거나 취소할 때 사용
+ */
+@Entity
+@Table(name = "schedule_exceptions",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"rule_id", "original_start_time"}))
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ScheduleException {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "rule_id", nullable = false)
+    private ScheduleRule rule;
+
+    @Column(name = "original_start_time", nullable = false)
+    private Instant originalStartTime;
+
+    @Column(name = "new_start_time")
+    private Instant newStartTime;
+
+    @Column(name = "new_end_time")
+    private Instant newEndTime;
+
+    @Column(name = "new_content", length = 40)
+    private String newContent;
+
+    @Column(name = "is_cancelled", nullable = false)
+    private Boolean isCancelled = false;
+
+}

--- a/back_end/src/main/java/com/jbnu/calelog/entity/ScheduleRule.java
+++ b/back_end/src/main/java/com/jbnu/calelog/entity/ScheduleRule.java
@@ -1,0 +1,70 @@
+package com.jbnu.calelog.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-19
+ * @description 반복 일정의 규칙을 저장하는 엔티티
+ *             iCalendar RFC 5545 표준 RRULE 형식을 지원
+ */
+@Entity
+@Table(name = "schedule_rules")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ScheduleRule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private Schedule.ScheduleType type;
+
+    @Column(name = "content", length = 40)
+    private String content;
+
+    @Column(name = "start_time_base", nullable = false)
+    private LocalTime startTimeBase;
+
+    @Column(name = "end_time_base", nullable = false)
+    private LocalTime endTimeBase;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "rrule", nullable = false, length = 255)
+    private String rrule;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @OneToMany(mappedBy = "rule", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ScheduleException> exceptions = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+    }
+
+}

--- a/back_end/src/main/java/com/jbnu/calelog/entity/User.java
+++ b/back_end/src/main/java/com/jbnu/calelog/entity/User.java
@@ -1,0 +1,53 @@
+package com.jbnu.calelog.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-19
+ * @description 사용자 계정 정보를 저장하는 엔티티 클래스
+ *             이메일 기반 로그인 및 JWT 인증을 지원
+ */
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email", nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @Column(name = "full_name", nullable = false, length = 50)
+    private String fullName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "auth_provider", nullable = false, length = 20)
+    private AuthProvider authProvider = AuthProvider.LOCAL;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+    }
+
+    public enum AuthProvider {
+        LOCAL
+    }
+
+}


### PR DESCRIPTION
6개 엔티티 클래스 구현:
- User: 사용자 계정 정보
- Project: 활동 프로젝트 관리
- MonthlyQuota: 프로젝트별 월간 목표 시간
- Schedule: 단일 일정 정보
- ScheduleRule: 반복 일정 규칙 (iCalendar RRULE 지원)
- ScheduleException: 반복 일정 예외 처리

UTC 기준 Instant 타입으로 시간 처리 통일
@PrePersist로 생성 시간 자동 설정