### PR TITLE
feat: 일정 관리 API 구현

### DIFF
--- a/back_end/build.gradle
+++ b/back_end/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 	
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/back_end/src/main/java/com/jbnu/calelog/config/GlobalExceptionHandler.java
+++ b/back_end/src/main/java/com/jbnu/calelog/config/GlobalExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.jbnu.calelog.config;
+
+import com.jbnu.calelog.dto.ScheduleConflictErrorDto;
+import com.jbnu.calelog.exception.ScheduleConflictException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-21
+ * @description 전역 예외 처리기
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ScheduleConflictException.class)
+    public ResponseEntity<ScheduleConflictErrorDto> handleScheduleConflict(ScheduleConflictException e) {
+        List<ScheduleConflictErrorDto.ConflictSchedule> conflictSchedules = 
+                e.getConflictingSchedules().stream()
+                        .map(schedule -> ScheduleConflictErrorDto.ConflictSchedule.builder()
+                                .id(schedule.getId())
+                                .title(schedule.getTitle())
+                                .startTime(schedule.getStartTime().toLocalTime())
+                                .endTime(schedule.getEndTime().toLocalTime())
+                                .build())
+                        .toList();
+
+        ScheduleConflictErrorDto errorResponse = ScheduleConflictErrorDto.builder()
+                .errorCode("SCHEDULE_CONFLICT")
+                .message(e.getMessage())
+                .conflictSchedules(conflictSchedules)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+}

--- a/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleConflictErrorDto.java
+++ b/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleConflictErrorDto.java
@@ -1,0 +1,36 @@
+package com.jbnu.calelog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-21
+ * @description 일정 중복 에러 응답 데이터
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleConflictErrorDto {
+    
+    private String errorCode;
+    private String message;
+    private List<ConflictSchedule> conflictSchedules;
+    
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ConflictSchedule {
+        private Long id;
+        private String title;
+        private LocalTime startTime;
+        private LocalTime endTime;
+    }
+}

--- a/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleCreateRequestDto.java
+++ b/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleCreateRequestDto.java
@@ -1,0 +1,59 @@
+package com.jbnu.calelog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-21
+ * @description 일정 생성 요청 데이터
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleCreateRequestDto {
+
+    @NotBlank(message = "일정 제목은 필수입니다")
+    private String title;
+
+    @NotNull(message = "일정 타입은 필수입니다")
+    private String type;
+
+    private Long projectId;
+
+    private String content;
+
+    @NotNull(message = "날짜는 필수입니다")
+    private LocalDate date;
+
+    @NotNull(message = "시작 시간은 필수입니다")
+    private LocalTime startTime;
+
+    @NotNull(message = "종료 시간은 필수입니다")
+    private LocalTime endTime;
+
+    private RepeatOptions repeat;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RepeatOptions {
+        @Builder.Default
+        private boolean enabled = false;
+        private String frequency;
+        private Integer interval;
+        private String[] days;
+        private String endType;
+        private LocalDate endDate;
+        private Integer endCount;
+    }
+}

--- a/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleCreateResponseDto.java
+++ b/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleCreateResponseDto.java
@@ -1,0 +1,37 @@
+package com.jbnu.calelog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-21
+ * @description 일정 생성 응답 데이터
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleCreateResponseDto {
+    
+    private ScheduleResponseDto mainSchedule;
+    private List<ScheduleResponseDto> schedules;
+    
+    public static ScheduleCreateResponseDto single(ScheduleResponseDto schedule) {
+        return ScheduleCreateResponseDto.builder()
+                .mainSchedule(schedule)
+                .schedules(List.of(schedule))
+                .build();
+    }
+    
+    public static ScheduleCreateResponseDto recurring(ScheduleResponseDto mainSchedule, List<ScheduleResponseDto> allSchedules) {
+        return ScheduleCreateResponseDto.builder()
+                .mainSchedule(mainSchedule)
+                .schedules(allSchedules)
+                .build();
+    }
+}

--- a/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleDeleteRequestDto.java
+++ b/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleDeleteRequestDto.java
@@ -1,0 +1,21 @@
+package com.jbnu.calelog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-21
+ * @description 일정 삭제 요청 데이터
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleDeleteRequestDto {
+    
+    @Builder.Default
+    private boolean deleteAllRecurrences = false;
+}

--- a/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleResponseDto.java
+++ b/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleResponseDto.java
@@ -1,0 +1,34 @@
+package com.jbnu.calelog.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-21
+ * @description 일정 조회 응답 데이터
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleResponseDto {
+    
+    private Long id;
+    private String title;
+    private LocalDateTime start;
+    private LocalDateTime end;
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String type;
+    private Long projectId;
+    private String content;
+    private String recurrenceId;
+}

--- a/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleUpdateRequestDto.java
+++ b/back_end/src/main/java/com/jbnu/calelog/dto/ScheduleUpdateRequestDto.java
@@ -1,0 +1,42 @@
+package com.jbnu.calelog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-21
+ * @description 일정 수정 요청 데이터
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleUpdateRequestDto {
+
+    @NotBlank(message = "일정 제목은 필수입니다")
+    private String title;
+
+    @NotNull(message = "일정 타입은 필수입니다")
+    private String type;
+
+    private Long projectId;
+
+    private String content;
+
+    @NotNull(message = "날짜는 필수입니다")
+    private LocalDate date;
+
+    @NotNull(message = "시작 시간은 필수입니다")
+    private LocalTime startTime;
+
+    @NotNull(message = "종료 시간은 필수입니다")
+    private LocalTime endTime;
+}

--- a/back_end/src/main/java/com/jbnu/calelog/exception/ScheduleConflictException.java
+++ b/back_end/src/main/java/com/jbnu/calelog/exception/ScheduleConflictException.java
@@ -1,0 +1,22 @@
+package com.jbnu.calelog.exception;
+
+import com.jbnu.calelog.entity.Schedule;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-21
+ * @description 일정 시간 중복 예외
+ */
+@Getter
+public class ScheduleConflictException extends RuntimeException {
+    
+    private final List<Schedule> conflictingSchedules;
+    
+    public ScheduleConflictException(String message, List<Schedule> conflictingSchedules) {
+        super(message);
+        this.conflictingSchedules = conflictingSchedules;
+    }
+}

--- a/back_end/src/main/java/com/jbnu/calelog/repository/ScheduleRepository.java
+++ b/back_end/src/main/java/com/jbnu/calelog/repository/ScheduleRepository.java
@@ -96,4 +96,11 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
      * @return 해당 그룹의 모든 일정
      */
     List<Schedule> findByRecurringGroupId(String recurringGroupId);
+
+    /**
+     * 반복 일정 그룹의 모든 일정 삭제 (소유권 검증 포함)
+     * @param recurringGroupId 반복 그룹 ID
+     * @param userId 사용자 ID
+     */
+    void deleteByRecurringGroupIdAndUserId(String recurringGroupId, Long userId);
 }

--- a/back_end/src/main/java/com/jbnu/calelog/security/JwtAuthenticationFilter.java
+++ b/back_end/src/main/java/com/jbnu/calelog/security/JwtAuthenticationFilter.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -50,9 +49,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         List.of(new SimpleGrantedAuthority("ROLE_USER")) // authorities
                     );
 
-                // 요청 세부 정보 설정
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                
                 // 사용자 ID를 추가 정보로 저장
                 authentication.setDetails(userId);
 

--- a/back_end/src/main/java/com/jbnu/calelog/service/ScheduleService.java
+++ b/back_end/src/main/java/com/jbnu/calelog/service/ScheduleService.java
@@ -1,0 +1,227 @@
+package com.jbnu.calelog.service;
+
+import com.jbnu.calelog.dto.*;
+import com.jbnu.calelog.dto.ScheduleCreateRequestDto.RepeatOptions;
+import com.jbnu.calelog.entity.Project;
+import com.jbnu.calelog.entity.Schedule;
+import com.jbnu.calelog.entity.User;
+import com.jbnu.calelog.exception.ScheduleConflictException;
+import com.jbnu.calelog.repository.ProjectRepository;
+import com.jbnu.calelog.repository.ScheduleRepository;
+import com.jbnu.calelog.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * @author Bae-Jihyeok, qowlgur121@gmail.com
+ * @date 2025-06-21
+ * @description 일정 관리 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+    private final UserRepository userRepository;
+    private final ProjectRepository projectRepository;
+
+    @Transactional(readOnly = true)
+    public List<ScheduleResponseDto> getMonthlySchedules(int year, int month, Long userId) {
+        List<Schedule> schedules = scheduleRepository.findByUserIdAndYearAndMonth(userId, year, month);
+        return schedules.stream()
+                .map(this::convertToResponseDto)
+                .toList();
+    }
+
+    public ScheduleCreateResponseDto createSchedule(ScheduleCreateRequestDto request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다"));
+
+        if (request.getRepeat() == null || !request.getRepeat().isEnabled()) {
+            Schedule schedule = createSingleScheduleFromRequest(request, user, null);
+            validateScheduleConflict(schedule);
+            Schedule savedSchedule = scheduleRepository.save(schedule);
+            ScheduleResponseDto responseDto = convertToResponseDto(savedSchedule);
+            return ScheduleCreateResponseDto.single(responseDto);
+        }
+
+        String groupId = UUID.randomUUID().toString();
+        List<Schedule> schedulesToCreate = generateSchedulesFromRepeatRule(request, user, groupId);
+        
+        validateScheduleConflicts(schedulesToCreate);
+        
+        List<Schedule> savedSchedules = scheduleRepository.saveAll(schedulesToCreate);
+        List<ScheduleResponseDto> allScheduleResponses = savedSchedules.stream()
+                .map(this::convertToResponseDto)
+                .toList();
+        
+        return ScheduleCreateResponseDto.recurring(allScheduleResponses.get(0), allScheduleResponses);
+    }
+
+    public ScheduleResponseDto updateSchedule(Long scheduleId, ScheduleUpdateRequestDto request, Long userId) {
+        Schedule schedule = scheduleRepository.findByIdAndUserId(scheduleId, userId)
+                .orElseThrow(() -> new RuntimeException("일정을 찾을 수 없습니다"));
+
+        updateScheduleFromRequest(schedule, request);
+        validateScheduleConflict(schedule);
+        
+        Schedule savedSchedule = scheduleRepository.save(schedule);
+        return convertToResponseDto(savedSchedule);
+    }
+
+    public void deleteSchedule(Long scheduleId, ScheduleDeleteRequestDto request, Long userId) {
+        Schedule schedule = scheduleRepository.findByIdAndUserId(scheduleId, userId)
+                .orElseThrow(() -> new RuntimeException("일정을 찾을 수 없습니다"));
+
+        if (request.isDeleteAllRecurrences() && schedule.getRecurringGroupId() != null) {
+            scheduleRepository.deleteByRecurringGroupIdAndUserId(schedule.getRecurringGroupId(), userId);
+        } else {
+            scheduleRepository.delete(schedule);
+        }
+    }
+
+    private Schedule createSingleScheduleFromRequest(ScheduleCreateRequestDto request, User user, String groupId) {
+        LocalDateTime start = LocalDateTime.of(request.getDate(), request.getStartTime());
+        LocalDateTime end = LocalDateTime.of(request.getDate(), request.getEndTime());
+
+        Project project = null;
+        if ("PROJECT".equals(request.getType()) && request.getProjectId() != null) {
+            project = projectRepository.findByIdAndUserId(request.getProjectId(), user.getId())
+                    .orElse(null);
+        }
+
+        return Schedule.builder()
+                .user(user)
+                .project(project)
+                .recurringGroupId(groupId)
+                .type(Schedule.ScheduleType.valueOf(request.getType()))
+                .title(request.getTitle())
+                .content(request.getContent())
+                .startTime(start)
+                .endTime(end)
+                .build();
+    }
+
+    private void updateScheduleFromRequest(Schedule schedule, ScheduleUpdateRequestDto request) {
+        LocalDateTime start = LocalDateTime.of(request.getDate(), request.getStartTime());
+        LocalDateTime end = LocalDateTime.of(request.getDate(), request.getEndTime());
+
+        Project project = null;
+        if ("PROJECT".equals(request.getType()) && request.getProjectId() != null) {
+            project = projectRepository.findByIdAndUserId(request.getProjectId(), schedule.getUser().getId())
+                    .orElse(null);
+        }
+
+        schedule.setTitle(request.getTitle());
+        schedule.setType(Schedule.ScheduleType.valueOf(request.getType()));
+        schedule.setProject(project);
+        schedule.setContent(request.getContent());
+        schedule.setStartTime(start);
+        schedule.setEndTime(end);
+    }
+
+    private List<Schedule> generateSchedulesFromRepeatRule(ScheduleCreateRequestDto request, User user, String groupId) {
+        List<Schedule> schedules = new ArrayList<>();
+        RepeatOptions repeat = request.getRepeat();
+        
+        LocalDate currentDate = request.getDate();
+        LocalDate endDate = "date".equals(repeat.getEndType()) ? repeat.getEndDate() : currentDate.plusMonths(6);
+        
+        int count = 0;
+        int maxCount = "count".equals(repeat.getEndType()) ? repeat.getEndCount() : 200;
+        
+        while (!currentDate.isAfter(endDate) && count < maxCount) {
+            if (shouldCreateScheduleOnDate(currentDate, request.getDate(), repeat)) {
+                Schedule schedule = createSingleScheduleFromRequest(
+                    ScheduleCreateRequestDto.builder()
+                        .title(request.getTitle())
+                        .type(request.getType())
+                        .projectId(request.getProjectId())
+                        .content(request.getContent())
+                        .date(currentDate)
+                        .startTime(request.getStartTime())
+                        .endTime(request.getEndTime())
+                        .build(),
+                    user, 
+                    groupId
+                );
+                schedules.add(schedule);
+                count++;
+            }
+            currentDate = currentDate.plusDays(1);
+        }
+        
+        return schedules;
+    }
+
+    private boolean shouldCreateScheduleOnDate(LocalDate date, LocalDate startDate, RepeatOptions repeat) {
+        if (date.isBefore(startDate)) {
+            return false;
+        }
+        
+        if ("weekly".equals(repeat.getFrequency())) {
+            int dayOfWeek = date.getDayOfWeek().getValue();
+            String dayStr = String.valueOf(dayOfWeek);
+            
+            if (repeat.getDays() != null) {
+                for (String day : repeat.getDays()) {
+                    if (dayStr.equals(day)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        
+        if ("daily".equals(repeat.getFrequency())) {
+            long daysBetween = java.time.temporal.ChronoUnit.DAYS.between(startDate, date);
+            return daysBetween % repeat.getInterval() == 0;
+        }
+        
+        return false;
+    }
+
+    private void validateScheduleConflict(Schedule newSchedule) {
+        List<Schedule> conflictingSchedules = scheduleRepository.findConflictingSchedules(
+                newSchedule.getUser().getId(),
+                newSchedule.getStartTime(),
+                newSchedule.getEndTime(),
+                newSchedule.getId()
+        );
+        
+        if (!conflictingSchedules.isEmpty()) {
+            throw new ScheduleConflictException("해당 시간에 이미 다른 일정이 존재합니다.", conflictingSchedules);
+        }
+    }
+
+    private void validateScheduleConflicts(List<Schedule> schedules) {
+        for (Schedule schedule : schedules) {
+            validateScheduleConflict(schedule);
+        }
+    }
+
+    private ScheduleResponseDto convertToResponseDto(Schedule schedule) {
+        return ScheduleResponseDto.builder()
+                .id(schedule.getId())
+                .title(schedule.getTitle())
+                .start(schedule.getStartTime())
+                .end(schedule.getEndTime())
+                .date(schedule.getStartTime().toLocalDate())
+                .startTime(schedule.getStartTime().toLocalTime())
+                .endTime(schedule.getEndTime().toLocalTime())
+                .type(schedule.getType().toString())
+                .projectId(schedule.getProject() != null ? schedule.getProject().getId() : null)
+                .content(schedule.getContent())
+                .recurrenceId(schedule.getRecurringGroupId())
+                .build();
+    }
+}


### PR DESCRIPTION
### 일정 관리 API
  - **POST** `/api/schedules` - 일정 생성 (단일/반복)
  - **GET** `/api/schedules` - 월별 일정 조회
  - **PUT** `/api/schedules/{id}` - 일정 수정
  - **DELETE** `/api/schedules/{id}` - 일정 삭제

  ### 주요 기능
  - 시간 중복 검증 (409 Conflict 응답)
  - 반복 일정 생성 (매일/매주/매월)
  - PROJECT 및 INACTIVE 일정 타입 지원
  - JWT 인증 기반 사용자별 데이터 격리

  ### 기술적 개선
  - SpringDoc OpenAPI 2.8.9로 버전 업데이트
  - JWT 필터 사용자 ID 추출 로직 개선
  - 글로벌 예외 처리 추가

  ## 테스트 확인
  - Swagger UI에서 모든 엔드포인트 테스트 완료
  - JWT 인증 동작 확인
  - 시간 중복 검증 로직 확인
  - 반복 일정 생성 확인